### PR TITLE
Make WASocket disposable

### DIFF
--- a/BaileysCSharp/Core/Events/EventEmitter.cs
+++ b/BaileysCSharp/Core/Events/EventEmitter.cs
@@ -21,8 +21,11 @@ namespace BaileysCSharp.Core.Events
 {
 
     public delegate void EventEmitterHandler<T>(T args);
-    public class EventEmitter
+    public class EventEmitter : IDisposable
     {
+        public void Dispose() {
+            Events.Clear();
+        }
         private object locker = new object();
         ConcurrentDictionary<string, IEventStore> Events = new ConcurrentDictionary<string, IEventStore>();
         public BaseSocket Sender { get; }

--- a/BaileysCSharp/Core/Helper/ProcessingMutex.cs
+++ b/BaileysCSharp/Core/Helper/ProcessingMutex.cs
@@ -1,11 +1,15 @@
 ﻿namespace BaileysCSharp.Core.Helper
 {
-    public class ProcessingMutex
+    public class ProcessingMutex : IDisposable
     {
+        public void Dispose()
+        {
+            semaphoreSlim.Dispose();
+        }
+
         SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
         public ProcessingMutex()
         {
-
         }
 
         public async Task Mutex(Action action)

--- a/BaileysCSharp/Core/Logging/Logger.cs
+++ b/BaileysCSharp/Core/Logging/Logger.cs
@@ -13,12 +13,14 @@ using System.Text.Unicode;
 
 namespace BaileysCSharp.Core.Logging
 {
-    public class DefaultLogger : ILogger
+    public class DefaultLogger : ILogger, IDisposable
     {
         public DefaultLogger()
         {
 
         }
+
+        public void Dispose() { }
 
         private static object locker = new object();
         public LogLevel Level { get; set; }

--- a/BaileysCSharp/Core/NoSQL/MemoryStore.cs
+++ b/BaileysCSharp/Core/NoSQL/MemoryStore.cs
@@ -11,8 +11,13 @@ using static BaileysCSharp.Core.Utils.JidUtils;
 
 namespace BaileysCSharp.Core.NoSQL
 {
-    public class MemoryStore
+    public class MemoryStore : IDisposable
     {
+        public void Dispose() 
+        {
+            database.Dispose();
+        }
+
         private static object locker = new object();
         LiteDB.LiteDatabase database;
 
@@ -67,6 +72,11 @@ namespace BaileysCSharp.Core.NoSQL
             messageList = messages.Where(x => x.RemoteJid != null).GroupBy(x => x.RemoteJid).ToDictionary(x => x.Key, x => x.Select(y => y.ToMessageInfo()).ToList());
             StartTimer();
             //Timer checkPoint = new Timer(OnCheckpoint, null, TimeSpan.Zero, TimeSpan.FromSeconds(30));
+        }
+
+        public void Destroy()
+        {
+            database.Dispose();
         }
 
         private void GroupParticipant_Update(object? sender, GroupParticipantUpdateModel e)

--- a/BaileysCSharp/Core/Signal/SignalRepository.cs
+++ b/BaileysCSharp/Core/Signal/SignalRepository.cs
@@ -10,8 +10,9 @@ using BaileysCSharp.Core.Types;
 
 namespace BaileysCSharp.Core.Signal
 {
-    public class SignalRepository
+    public class SignalRepository : IDisposable
     {
+        public void Dispose() {}
         public SignalStorage Storage { get; set; }
         public SignalRepository(AuthenticationState auth)
         {

--- a/BaileysCSharp/Core/Sockets/ChatSocket.cs
+++ b/BaileysCSharp/Core/Sockets/ChatSocket.cs
@@ -18,6 +18,12 @@ namespace BaileysCSharp.Core
 {
     public abstract class ChatSocket : BaseSocket
     {
+        public new void Dispose()
+        {
+            processingMutex.Dispose();
+            base.Dispose();
+        }
+
         protected ProcessingMutex processingMutex;
 
         public ChatSocket([NotNull] SocketConfig config) : base(config)
@@ -463,7 +469,7 @@ namespace BaileysCSharp.Core
                     {"xmlns","usync" }
                 },
                 content = new BinaryNode[]
-                {
+                    {
                     new BinaryNode()
                     {
                         tag = "usync",
@@ -489,7 +495,7 @@ namespace BaileysCSharp.Core
                             }
                         }
                     }
-                }
+                    }
             });
 
             var usyncNode = GetBinaryNodeChild(result, "usync");

--- a/BaileysCSharp/Core/Sockets/Client/AbstractSocketClient.cs
+++ b/BaileysCSharp/Core/Sockets/Client/AbstractSocketClient.cs
@@ -9,8 +9,15 @@ using BaileysCSharp.Core.Models;
 
 namespace BaileysCSharp.Core.Sockets.Client
 {
-    public abstract class AbstractSocketClient
+    public abstract class AbstractSocketClient : IDisposable
     {
+        public virtual void Dispose() {
+            Disconnect();
+            Disconnected = null!;
+            Opened = null!;
+            ConnectFailed = null!;
+            Error = null!;
+        }
         protected AbstractSocketClient(BaseSocket socket)
         {
             Socket = socket;

--- a/BaileysCSharp/Core/Sockets/Client/WebSocketClient.cs
+++ b/BaileysCSharp/Core/Sockets/Client/WebSocketClient.cs
@@ -6,6 +6,13 @@ namespace BaileysCSharp.Core.Sockets.Client
     public class WebSocketClient : AbstractSocketClient
     {
         ClientWebSocket WebSocket;
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            WebSocket.Abort();
+            WebSocket?.Dispose();
+        }
         public WebSocketClient(BaseSocket wasocket) : base(wasocket)
         {
         }

--- a/BaileysCSharp/Core/Sockets/MessagesRecvSocket.cs
+++ b/BaileysCSharp/Core/Sockets/MessagesRecvSocket.cs
@@ -20,6 +20,12 @@ namespace BaileysCSharp.Core.Sockets
 {
     public abstract class MessagesRecvSocket : MessagesSendSocket
     {
+        public new void Dispose()
+        {
+            events.Clear();
+            base.Dispose();
+            EV.Connection.Update -= Connection_Update;
+        }
         //public bool SendActiveReceipts;
         public long MaxMsgRetryCount { get; set; } = 5;
         private static Mutex mut = new Mutex();

--- a/BaileysCSharp/Core/Sockets/MessagesSendSocket.cs
+++ b/BaileysCSharp/Core/Sockets/MessagesSendSocket.cs
@@ -33,6 +33,12 @@ namespace BaileysCSharp.Core.Sockets
 
     public abstract class MessagesSendSocket : GroupSocket
     {
+        public new void Dispose()
+        {
+            userDevicesCache.Dispose();
+            base.Dispose();
+        }
+
         public MediaConnInfo CurrentMedia { get; set; }
 
         NodeCache userDevicesCache = new NodeCache();

--- a/BaileysCSharp/Core/Utils/NoiseHandler.cs
+++ b/BaileysCSharp/Core/Utils/NoiseHandler.cs
@@ -10,8 +10,13 @@ using System.Text;
 
 namespace BaileysCSharp.Core.Utils
 {
-    public class NoiseHandler
+    public class NoiseHandler : IDisposable
     {
+        public void Dispose()
+        {
+            OnFrame = null;
+        }
+
         public event EventHandler<BinaryNode> OnFrame;
 
         public NoiseHandler(KeyPair ephemeralKeyPair, DefaultLogger logger)


### PR DESCRIPTION
✅ Added a dispose method to WASocket and its components to ensure proper resource management and cleanup.

Coalited components that have been changed:
  - EventEmitter
  - ProcessingMutex
  - Logger
  - MemoryStore
  - SignalRepository
  - BaseSocket
  - ChatSocket
  - AbstractSocketClient
  - WebSocketClient
  - MessagesRecvSocket
  - MessagesSendSocket
  - NoiseHandler
 
Example usage:
```csharp
socket = new WASocket(config);

socket.EndConnection(destroyStore: true);
socket.Dispose();
// allowing a new instantiation
```

Also added an event emitted when disconnecting:
```csharp
// BaseSocket.cs
private void Client_Disconnected(AbstractSocketClient sender, DisconnectReason reason)
{
    WS.Opened -= Client_Opened;
    WS.Disconnected -= Client_Disconnected;
    WS.MessageRecieved -= Client_MessageRecieved;
    EV.Emit(EmitType.Update, new ConnectionState()
    {
        Connection = WAConnectionState.Close,
        LastDisconnect = new LastDisconnect()
        {
            Date = DateTime.Now,
        }
    });
}
```